### PR TITLE
Docs // Iterate README/TODO and harden issue-demo workflow

### DIFF
--- a/.github/workflows/issue-demo.yml
+++ b/.github/workflows/issue-demo.yml
@@ -48,8 +48,16 @@ jobs:
             printf '%s\n' 'No issue description provided. Please summarize this issue and propose next steps.' > .tmp/issue-body.txt
           fi
 
+          if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENCODE_API_KEY:-}" ]; then
+            {
+              printf '%s\n\n' 'No model provider credentials are configured for this repository.'
+              printf '%s\n' 'Set at least one secret (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENCODE_API_KEY`) and rerun the workflow.'
+            } > .tmp/opencode-response.txt
+            exit 0
+          fi
+
           set +e
-          docker compose run --rm \
+          timeout 180s docker compose run --rm \
             -e OPENAI_API_KEY \
             -e ANTHROPIC_API_KEY \
             -e OPENCODE_API_KEY \
@@ -61,11 +69,21 @@ jobs:
 
           if [ "$exit_code" -ne 0 ]; then
             cp .tmp/opencode-response.txt .tmp/opencode-error.txt
-            {
-              printf '%s\n\n' "OpenCode invocation failed with exit code ${exit_code}."
-              printf '%s\n' 'Workflow captured logs:'
-              cat .tmp/opencode-error.txt
-            } > .tmp/opencode-response.txt
+
+            if [ "$exit_code" -eq 124 ]; then
+              {
+                printf '%s\n\n' 'OpenCode invocation timed out after 180 seconds.'
+                printf '%s\n\n' 'Confirm model provider credentials are valid and that `opencode run` can complete non-interactively in the container.'
+                printf '%s\n' 'Workflow captured logs:'
+                cat .tmp/opencode-error.txt
+              } > .tmp/opencode-response.txt
+            else
+              {
+                printf '%s\n\n' "OpenCode invocation failed with exit code ${exit_code}."
+                printf '%s\n' 'Workflow captured logs:'
+                cat .tmp/opencode-error.txt
+              } > .tmp/opencode-response.txt
+            fi
           fi
 
       - name: Post OpenCode response

--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ The `Issue Demo` GitHub Action runs on issue open/edit events and via manual dis
 - Passes issue text into `opencode run`.
 - Posts OpenCode output back to the issue as a comment.
 
-Optional secrets for model provider credentials:
+Model provider credential secrets:
 
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `OPENCODE_API_KEY`
+
+If none are configured, the workflow posts a guidance message instead of attempting a model call.
 
 ## Planning and Templates
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 ## Agent Runtime Backlog
 
+- [x] Guard issue demo workflow against missing credentials and stalled OpenCode runs
 - [ ] Setup `ocx` profiles for core agent roles and stages
 - [ ] Implement profile launcher that selects profile by action/event type and stage
   - [ ] Map issue planning flow (example: `issue_planning`)

--- a/docs/context/github-operator-loop.md
+++ b/docs/context/github-operator-loop.md
@@ -22,6 +22,16 @@ gh label create Accepted --description "Implementation accepted" --color C5DEF5
 
 If labels already exist, `gh` will return an error for that label; this is safe to ignore.
 
+3. Configure at least one model credential secret if you want model-generated issue replies:
+
+```bash
+gh secret set OPENAI_API_KEY
+# or
+gh secret set ANTHROPIC_API_KEY
+# or
+gh secret set OPENCODE_API_KEY
+```
+
 ## Issue to Branch
 
 1. Create an issue from template:


### PR DESCRIPTION
## Summary
- rewrites `README.md` for clearer quick start, issue lifecycle labels, and GitHub CLI loop usage
- reorganizes `TODO.md` into runtime backlog + docs/process status and records completed docs hardening work
- adds `docs/context/github-operator-loop.md` runbook for issue -> branch -> PR -> merge operations
- hardens `.github/workflows/issue-demo.yml` by handling missing credential secrets early and enforcing a 180s timeout around `opencode run`

## Verification
- `gh run watch 22219530557 --interval 5 --exit-status` (workflow_dispatch on this branch) completed successfully
- confirmed branch push and issue label flow updates for `#7`

## Risks / Follow-ups
- issue-triggered run `22219314111` on `main` was manually canceled after hanging in `Generate OpenCode response from issue body`; this PR adds timeout + guidance messaging to prevent repeated hangs
- a separate clean-up PR may be useful to reduce verbose action output formatting if desired

Closes #7