### PR TITLE
System // Add OpenRouter provider path to issue-demo workflow

### DIFF
--- a/.github/workflows/issue-demo.yml
+++ b/.github/workflows/issue-demo.yml
@@ -11,6 +11,11 @@ on:
         description: "Issue body to pass to opencode run"
         required: true
         type: string
+      model:
+        description: "Optional model override in provider/model format"
+        required: false
+        default: ""
+        type: string
   issues:
     types: [opened, edited]
 
@@ -25,6 +30,7 @@ jobs:
     env:
       ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
       ISSUE_BODY: ${{ github.event.issue.body || inputs.issue_body }}
+      OPENCODE_MODEL: ${{ inputs.model || vars.OPENCODE_MODEL || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,6 +46,8 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENCODE_MODEL: ${{ env.OPENCODE_MODEL }}
         run: |
           mkdir -p .tmp
           printf '%s\n' "$ISSUE_BODY" > .tmp/issue-body.txt
@@ -48,10 +56,18 @@ jobs:
             printf '%s\n' 'No issue description provided. Please summarize this issue and propose next steps.' > .tmp/issue-body.txt
           fi
 
-          if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENCODE_API_KEY:-}" ]; then
+          if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ -z "${OPENCODE_API_KEY:-}" ] && [ -z "${OPENROUTER_API_KEY:-}" ]; then
             {
               printf '%s\n\n' 'No model provider credentials are configured for this repository.'
-              printf '%s\n' 'Set at least one secret (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENCODE_API_KEY`) and rerun the workflow.'
+              printf '%s\n' 'Set at least one secret (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENCODE_API_KEY`, or `OPENROUTER_API_KEY`) and rerun the workflow.'
+            } > .tmp/opencode-response.txt
+            exit 0
+          fi
+
+          if [ -n "${OPENCODE_MODEL:-}" ] && [ "${OPENCODE_MODEL#openrouter/}" != "${OPENCODE_MODEL}" ] && [ -z "${OPENROUTER_API_KEY:-}" ]; then
+            {
+              printf '%s\n\n' "OpenCode model override requires OpenRouter credentials: ${OPENCODE_MODEL}"
+              printf '%s\n' 'Set `OPENROUTER_API_KEY` or choose a non-OpenRouter model override.'
             } > .tmp/opencode-response.txt
             exit 0
           fi
@@ -61,8 +77,10 @@ jobs:
             -e OPENAI_API_KEY \
             -e ANTHROPIC_API_KEY \
             -e OPENCODE_API_KEY \
+            -e OPENROUTER_API_KEY \
+            -e OPENCODE_MODEL \
             devbox \
-            bash -lc 'ISSUE_DESC="$(cat /workspace/.tmp/issue-body.txt)" && opencode run "$ISSUE_DESC"' \
+            bash -lc 'ISSUE_DESC="$(cat /workspace/.tmp/issue-body.txt)" && if [ -n "${OPENCODE_MODEL:-}" ]; then opencode run --model "$OPENCODE_MODEL" "$ISSUE_DESC"; else opencode run "$ISSUE_DESC"; fi' \
             > .tmp/opencode-response.txt 2>&1
           exit_code=$?
           set -e

--- a/README.md
+++ b/README.md
@@ -111,8 +111,14 @@ Model provider credential secrets:
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `OPENCODE_API_KEY`
+- `OPENROUTER_API_KEY`
 
 If none are configured, the workflow posts a guidance message instead of attempting a model call.
+
+Optional model override:
+
+- `OPENCODE_MODEL` repository variable (for example: `openrouter/openai/gpt-5-mini`)
+- `workflow_dispatch` input `model`
 
 ## Planning and Templates
 
@@ -143,4 +149,10 @@ To manually run the issue demo workflow for a specific issue:
 
 ```bash
 gh workflow run issue-demo.yml -f issue_number=123 -f issue_body="$(gh issue view 123 --json body -q .body)"
+```
+
+To force an OpenRouter model on manual dispatch:
+
+```bash
+gh workflow run issue-demo.yml -f issue_number=123 -f issue_body="$(gh issue view 123 --json body -q .body)" -f model="openrouter/openai/gpt-5-mini"
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 ## Agent Runtime Backlog
 
 - [x] Guard issue demo workflow against missing credentials and stalled OpenCode runs
+- [x] Add OpenRouter credential/model override path in issue demo workflow
 - [ ] Setup `ocx` profiles for core agent roles and stages
 - [ ] Implement profile launcher that selects profile by action/event type and stage
   - [ ] Map issue planning flow (example: `issue_planning`)

--- a/docs/context/github-operator-loop.md
+++ b/docs/context/github-operator-loop.md
@@ -30,6 +30,19 @@ gh secret set OPENAI_API_KEY
 gh secret set ANTHROPIC_API_KEY
 # or
 gh secret set OPENCODE_API_KEY
+# or
+gh secret set OPENROUTER_API_KEY
+```
+
+4. Optional: set a repository-level default model override:
+
+```bash
+gh api --method POST repos/CursedFactory/cursed-fab/actions/variables \
+  -f name='OPENCODE_MODEL' \
+  -f value='openrouter/openai/gpt-5-mini' \
+  || gh api --method PATCH repos/CursedFactory/cursed-fab/actions/variables/OPENCODE_MODEL \
+    -f name='OPENCODE_MODEL' \
+    -f value='openrouter/openai/gpt-5-mini'
 ```
 
 ## Issue to Branch
@@ -91,6 +104,12 @@ Run against a specific issue body using `workflow_dispatch`:
 
 ```bash
 gh workflow run issue-demo.yml -f issue_number=<issue-number> -f issue_body="$(gh issue view <issue-number> --json body -q .body)"
+```
+
+Run with explicit model override:
+
+```bash
+gh workflow run issue-demo.yml -f issue_number=<issue-number> -f issue_body="$(gh issue view <issue-number> --json body -q .body)" -f model="openrouter/openai/gpt-5-mini"
 ```
 
 Inspect the latest runs:


### PR DESCRIPTION
## Summary
- adds optional `workflow_dispatch` input `model` and job-level `OPENCODE_MODEL` support in `.github/workflows/issue-demo.yml`
- extends credential handling to include `OPENROUTER_API_KEY`, including guardrails when an OpenRouter model is requested without an OpenRouter key
- passes `OPENROUTER_API_KEY` and `OPENCODE_MODEL` into the devbox container and conditionally runs `opencode run --model ...`
- updates docs (`README.md`, `docs/context/github-operator-loop.md`, `TODO.md`) to document OpenRouter secret setup and model override flow

## Verification
- `gh workflow run issue-demo.yml --ref vfp/agent/openrouter-issue-demo-provider -f issue_number=9 -f issue_body="$(gh issue view 9 --json body -q .body)"`
- `gh run watch 22219953208 --interval 5 --exit-status` (completed successfully)
- issue comment for the run shows model selection moved away from default `big-pickle` to `openai/gpt-5-mini`

## Ops Changes
- set repository secret: `OPENROUTER_API_KEY`
- set repository variable: `OPENCODE_MODEL=openrouter/openai/gpt-5-mini`

Closes #9