### PR TITLE
CI // Fix PR implementation workflow HOME handling for mapped UID

### DIFF
--- a/.github/workflows/pr-stage-implement.yml
+++ b/.github/workflows/pr-stage-implement.yml
@@ -178,13 +178,14 @@ jobs:
             -u "$(id -u):$(id -g)" \
             -v "$PWD:/workspace" \
             -w /workspace \
+            -e HOME=/tmp/opencode-home \
             -e OPENAI_API_KEY \
             -e ANTHROPIC_API_KEY \
             -e OPENCODE_API_KEY \
             -e OPENROUTER_API_KEY \
             -e OPENCODE_MODEL \
             "$DEVBOX_IMAGE" \
-            bash -lc 'PROMPT="$(cat /workspace/.tmp/pr-implement-prompt.txt)" && if [ -n "${OPENCODE_MODEL:-}" ]; then opencode run --format json --model "$OPENCODE_MODEL" "$PROMPT"; else opencode run --format json "$PROMPT"; fi' \
+            bash -lc 'mkdir -p "$HOME" && PROMPT="$(cat /workspace/.tmp/pr-implement-prompt.txt)" && if [ -n "${OPENCODE_MODEL:-}" ]; then opencode run --format json --model "$OPENCODE_MODEL" "$PROMPT"; else opencode run --format json "$PROMPT"; fi' \
             > .tmp/opencode-events.jsonl 2>&1
           exit_code=$?
           set -e

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - [x] Improve issue reply formatting with structured prompt contract (`REPLY.md`) and clean comment output
 - [x] Remove unused default labels and add label governance workflow
 - [x] Add develop kickoff fallback path when workflow token cannot create PRs
+- [x] Fix PR implementation container HOME path when running under mapped UID
 - [ ] Setup `ocx` profiles for core agent roles and stages
 - [ ] Implement profile launcher that selects profile by action/event type and stage
   - [ ] Map issue planning flow (example: `issue_planning`)


### PR DESCRIPTION
## Summary
- updates `.github/workflows/pr-stage-implement.yml` to set `HOME=/tmp/opencode-home` when running container with mapped host UID
- creates the HOME directory before invoking OpenCode so CLI state initialization no longer targets `/.local`
- keeps mapped UID behavior (needed for writable workspace edits) while removing the home-path permission failure
- updates `TODO.md` to record the fix

## Verification
- Local sanity check (mapped UID):
  - `docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp/opencode-home -v "$PWD:/workspace" -w /workspace cursed-fab-devbox:local bash -lc 'mkdir -p "$HOME" && opencode --version'`
  - result: OpenCode CLI version printed successfully
- Workflow validation:
  - `gh workflow run pr-stage-implement.yml --ref vfp/agent/pr-implement-home-fix -f pr_number=18 -f task="Create VFP.md at repo root with a short overview of the stage workflow and mention issue #11."`
  - `gh run watch 22238605630 --interval 5 --exit-status` (successful)
  - PR #18 now contains an implementation update comment with `VFP.md` listed under applied changes

Closes #19